### PR TITLE
Update gizmo null fix and update Godot project to 4.4

### DIFF
--- a/addons/proto_shape/plugin.cfg
+++ b/addons/proto_shape/plugin.cfg
@@ -3,5 +3,5 @@
 name="ProtoShape"
 description="ProtoShape is a Godot plugin that adds a library of dynamic shapes like ramps and stairs to quickly block out your maps and iterate on your ideas. Create your custom dynamic shapes more easily with the included Gizmo system."
 author="Illyan"
-version="1.1.4"
+version="1.1.5"
 script="proto_shape.gd"

--- a/addons/proto_shape/proto_gizmo/proto_gizmo.gd.uid
+++ b/addons/proto_shape/proto_gizmo/proto_gizmo.gd.uid
@@ -1,0 +1,1 @@
+uid://dld6sttc0b5f3

--- a/addons/proto_shape/proto_gizmo/proto_gizmo_utils.gd.uid
+++ b/addons/proto_shape/proto_gizmo/proto_gizmo_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://cs58a4cejxs6p

--- a/addons/proto_shape/proto_gizmo_wrapper/proto_gizmo_wrapper.gd.uid
+++ b/addons/proto_shape/proto_gizmo_wrapper/proto_gizmo_wrapper.gd.uid
@@ -1,0 +1,1 @@
+uid://wr0twoe15d87

--- a/addons/proto_shape/proto_ramp/proto_ramp.gd.uid
+++ b/addons/proto_shape/proto_ramp/proto_ramp.gd.uid
@@ -1,0 +1,1 @@
+uid://briioihkxilxm

--- a/addons/proto_shape/proto_ramp/proto_ramp_gizmos.gd
+++ b/addons/proto_shape/proto_ramp/proto_ramp_gizmos.gd
@@ -28,6 +28,15 @@ func remove_ramp() -> void:
 		parent.redraw_gizmos_for_child_signal.disconnect(redraw_gizmos)
 		parent.set_handle_for_child_signal.disconnect(set_handle)
 		parent.commit_handle.disconnect(commit_handle)
+	# Disconnecting any leftover connections
+	if plugin != null:
+		if current_fine_snap_callable != null:
+			if plugin.fine_snapping_changed.is_connected(current_fine_snap_callable):
+				plugin.fine_snapping_changed.disconnect(current_fine_snap_callable)
+		if current_snap_callable != null:
+			if plugin.snapping_changed.is_connected(current_snap_callable):
+				plugin.snapping_changed.disconnect(current_snap_callable)
+		plugin = null
 	ramp = null
 
 # Snapping to grid
@@ -36,22 +45,47 @@ var snap_unit: float = 1.0
 var fine_snapping_enabled: bool = false
 var fine_snap_unit: float = 0.1
 
+# Captured arguments required for signal connections
+#  ramp: ProtoRamp - on closing a scene, the ramp is freed, so we need to check for null
+#    Unfortunately, disconnecting does not work (bug?), the lambda is still called afterwards
+#  plugin: ProtoGizmoPlugin - captured plugin argument will not be null (even after setting the field to null in remove_ramp)
+func node_snap_listener(ramp: ProtoRamp, plugin: ProtoGizmoPlugin) -> Callable:
+	return func (enabled: bool) -> void:
+		snapping_enabled = enabled
+		if ramp != null:
+			ramp.update_gizmos()
+		else:
+			plugin.snapping_changed.disconnect(current_snap_callable)
+
+func node_fine_snap_listener(ramp: ProtoRamp, plugin: ProtoGizmoPlugin) -> Callable:
+	return func (enabled: bool) -> void:
+		fine_snapping_enabled = enabled
+		if ramp != null:
+			ramp.update_gizmos()
+		else:
+			plugin.fine_snapping_changed.disconnect(current_fine_snap_callable)
+
+var current_snap_callable: Callable
+
+var current_fine_snap_callable: Callable
+
+var plugin: ProtoGizmoPlugin
+
 func init_gizmo(plugin: ProtoGizmoPlugin) -> void:
-	# Generate a random id for each gizmo
-	width_gizmo_id = randi_range(1_000, 1_000_000)
+	# Generate a "random" id for each gizmo
+	width_gizmo_id = Time.get_ticks_usec()
 	depth_gizmo_id = width_gizmo_id + 1
 	height_gizmo_id = width_gizmo_id + 2
 	fill_gizmo_id1 = width_gizmo_id + 3
 	fill_gizmo_id2 = width_gizmo_id + 4
 	undo_redo = plugin.undo_redo
-	plugin.fine_snapping_changed.connect(func (fine_snapping: bool) -> void:
-		fine_snapping_enabled = fine_snapping
-		ramp.update_gizmos()
-	)
-	plugin.snapping_changed.connect(func (snapping: bool) -> void:
-		snapping_enabled = snapping
-		ramp.update_gizmos()
-	)
+	plugin = plugin
+	current_snap_callable = node_snap_listener(ramp, plugin)
+	current_fine_snap_callable = node_fine_snap_listener(ramp, plugin)
+	plugin.fine_snapping_changed.connect(current_fine_snap_callable)
+	plugin.snapping_changed.connect(current_snap_callable)
+	snapping_enabled = plugin.snapping
+	fine_snapping_enabled = plugin.fine_snapping
 
 # Debug purposes
 var screen_pos: Vector2

--- a/addons/proto_shape/proto_ramp/proto_ramp_gizmos.gd.uid
+++ b/addons/proto_shape/proto_ramp/proto_ramp_gizmos.gd.uid
@@ -1,0 +1,1 @@
+uid://chy0qm1esgcji

--- a/addons/proto_shape/proto_shape.gd.uid
+++ b/addons/proto_shape/proto_shape.gd.uid
@@ -1,0 +1,1 @@
+uid://bw3q4nuh1nyfu

--- a/addons/proto_shape/scenes/Camera3D.gd.uid
+++ b/addons/proto_shape/scenes/Camera3D.gd.uid
@@ -1,0 +1,1 @@
+uid://7a8og04b8bqs

--- a/addons/proto_shape/scenes/CharacterBody3D.gd.uid
+++ b/addons/proto_shape/scenes/CharacterBody3D.gd.uid
@@ -1,0 +1,1 @@
+uid://dbi1dsujlxbfx

--- a/addons/proto_shape/scenes/proto_ramp_logo.tscn
+++ b/addons/proto_shape/scenes/proto_ramp_logo.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://drys0h14kvoud"]
 
-[ext_resource type="Script" path="res://addons/proto_shape/proto_ramp/proto_ramp.gd" id="2_i41uw"]
+[ext_resource type="Script" uid="uid://briioihkxilxm" path="res://addons/proto_shape/proto_ramp/proto_ramp.gd" id="2_i41uw"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_bk5re"]
 sun_angle_max = 60.0

--- a/addons/proto_shape/scenes/prototype_scene.tscn
+++ b/addons/proto_shape/scenes/prototype_scene.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=11 format=3 uid="uid://kh6kodj0l0ld"]
 
-[ext_resource type="Script" path="res://addons/proto_shape/scenes/CharacterBody3D.gd" id="1_4rry8"]
-[ext_resource type="Script" path="res://addons/proto_shape/scenes/Camera3D.gd" id="2_5cyg4"]
-[ext_resource type="Script" path="res://addons/proto_shape/proto_gizmo_wrapper/proto_gizmo_wrapper.gd" id="4_3jo5l"]
-[ext_resource type="Script" path="res://addons/proto_shape/proto_ramp/proto_ramp.gd" id="4_durks"]
+[ext_resource type="Script" uid="uid://dbi1dsujlxbfx" path="res://addons/proto_shape/scenes/CharacterBody3D.gd" id="1_4rry8"]
+[ext_resource type="Script" uid="uid://7a8og04b8bqs" path="res://addons/proto_shape/scenes/Camera3D.gd" id="2_5cyg4"]
+[ext_resource type="Script" uid="uid://wr0twoe15d87" path="res://addons/proto_shape/proto_gizmo_wrapper/proto_gizmo_wrapper.gd" id="4_3jo5l"]
+[ext_resource type="Script" uid="uid://briioihkxilxm" path="res://addons/proto_shape/proto_ramp/proto_ramp.gd" id="4_durks"]
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_s4hfa"]
 

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Test"
 run/main_scene="res://addons/proto_shape/scenes/prototype_scene.tscn"
-config/features=PackedStringArray("4.3", "Forward Plus")
+config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://addons/proto_shape/icon/proto-shape-icon.png"
 
 [editor_plugins]


### PR DESCRIPTION
3rd time's the charm!

Finally got a solution working. There is probably a bug in Godot, where a lambda callable is not disconnected from a signal and is still called after a captured argument is freed (that is why there was a null exception on update_gizmos function call).

This solution now actively disconnects the lambda from the signal when the ramp is exiting the scene tree (called by ProtoRamp) and when the lambda is called with a null (because the ramp is freed). This is possible as the plugin is also captured now, not depending on the current state/instance of ProtoGizmo.

Fixes #35